### PR TITLE
Pull Request Fraction w/out Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,19 @@ client/build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Python
+*.pyc
+__pycache__
+.pytest_cache/
+venv/
+
+# Rust
+target/
+Cargo.lock
+**/*.rs.bk
+*.pdb
+
+# Misc.
+.vscode/
+

--- a/server/cloc_files.json
+++ b/server/cloc_files.json
@@ -1,0 +1,39 @@
+
+{"header" : {
+  "cloc_url"           : "github.com/AlDanial/cloc",
+  "cloc_version"       : "1.90",
+  "elapsed_seconds"    : 0.0322608947753906,
+  "n_files"            : 5,
+  "n_lines"            : 179,
+  "files_per_second"   : 154.986401797328,
+  "lines_per_second"   : 5548.51318434433},
+"Repo-Analysis/package.json" :{
+  "blank": 0,
+  "comment": 0,
+  "code": 49,
+  "language": "JSON"},
+"Repo-Analysis/README.md" :{
+  "blank": 17,
+  "comment": 0,
+  "code": 29,
+  "language": "Markdown"},
+"Repo-Analysis/.verb.md" :{
+  "blank": 14,
+  "comment": 0,
+  "code": 24,
+  "language": "Markdown"},
+"Repo-Analysis/test.js" :{
+  "blank": 6,
+  "comment": 6,
+  "code": 17,
+  "language": "JavaScript"},
+"Repo-Analysis/index.js" :{
+  "blank": 3,
+  "comment": 6,
+  "code": 8,
+  "language": "JavaScript"},
+"SUM": {
+  "blank": 40,
+  "comment": 12,
+  "code": 127,
+  "nFiles": 5} }

--- a/server/src/inputs/commands/cloc_files.json
+++ b/server/src/inputs/commands/cloc_files.json
@@ -1,0 +1,39 @@
+
+{"header" : {
+  "cloc_url"           : "github.com/AlDanial/cloc",
+  "cloc_version"       : "1.90",
+  "elapsed_seconds"    : 0.0141470432281494,
+  "n_files"            : 5,
+  "n_lines"            : 179,
+  "files_per_second"   : 353.430743043969,
+  "lines_per_second"   : 12652.8206009741},
+"Repo-Analysis/package.json" :{
+  "blank": 0,
+  "comment": 0,
+  "code": 49,
+  "language": "JSON"},
+"Repo-Analysis/README.md" :{
+  "blank": 17,
+  "comment": 0,
+  "code": 29,
+  "language": "Markdown"},
+"Repo-Analysis/.verb.md" :{
+  "blank": 14,
+  "comment": 0,
+  "code": 24,
+  "language": "Markdown"},
+"Repo-Analysis/test.js" :{
+  "blank": 6,
+  "comment": 6,
+  "code": 17,
+  "language": "JavaScript"},
+"Repo-Analysis/index.js" :{
+  "blank": 3,
+  "comment": 6,
+  "code": 8,
+  "language": "JavaScript"},
+"SUM": {
+  "blank": 40,
+  "comment": 12,
+  "code": 127,
+  "nFiles": 5} }

--- a/server/src/inputs/commands/metrics.json
+++ b/server/src/inputs/commands/metrics.json
@@ -2,22 +2,31 @@
     "https://github.com/cloudinary/cloudinary_npm": {
         "RampUp": 0.73,
         "License": 0,
-        "Correctness": 0.66,
+        "Correctness": 0.67,
         "ResponsiveMaintainer": 0.68,
-        "BusFactor": 0.62
+        "BusFactor": 0.62,
+        "PR_Fraction": 0.63
     },
     "https://www.npmjs.com/package/express": {
-        "RampUp": 1.0,
         "License": 1,
-        "Correctness": 0.94,
-        "ResponsiveMaintainer": 0.75,
-        "BusFactor": 0.58
+        "Correctness": 0.95,
+        "ResponsiveMaintainer": 0.85,
+        "BusFactor": 0.58,
+        "PR_Fraction": 0.83
     },
     "https://github.com/nullivex/nodist": {
-        "RampUp": 0.83,
         "License": 1,
         "Correctness": 0,
-        "ResponsiveMaintainer": 0.35,
-        "BusFactor": 0.72
+        "ResponsiveMaintainer": 0.34,
+        "BusFactor": 0.72,
+        "PR_Fraction": 0.8
+    },
+    "https://github.com/jonschlinkert/even": {
+        "RampUp": 0.52,
+        "License": 1,
+        "Correctness": 1.0,
+        "ResponsiveMaintainer": 0.5,
+        "BusFactor": 0.88,
+        "PR_Fraction": 0.0
     }
 }

--- a/server/src/inputs/commands/pr_fraction.py
+++ b/server/src/inputs/commands/pr_fraction.py
@@ -1,0 +1,89 @@
+import subprocess
+import json
+import sys
+import os, shutil
+import valid_url as vu
+import pr_gql
+import git
+import re
+
+token = os.getenv("GITHUB_TOKEN")
+
+def score(url, orig_url, owner_repo, jsonfile):
+    
+    # Creates Local Repo Folder if non-existing, else remove it
+    path = "Repo-Analysis"
+    if(os.path.isdir(path)):
+        shutil.rmtree(path)
+    
+    # Clones the Repository Locally inside the Path folder
+    git.Repo.clone_from(url, path)
+
+    # Run and store cloc data to json file
+    with open('cloc_files.json', 'w') as f:
+        subprocess.check_call(['cloc', '--by-file', '--json', path], stdout=f)
+    cloc_json = open('cloc_files.json')
+    cloc_data = json.load(cloc_json)
+    
+    list_of_files = []
+    filename_regex = r"/([^/]+)$" # Regex function to get file name from path
+
+    # Get Total Lines of Code and list of analyzed files
+    for item in cloc_data:
+        match = re.search(filename_regex, item)  # Regex function used to check if there is a path to a file
+        if match:
+            match_filename = item.replace("Repo-Analysis/", "")
+            list_of_files.append(match_filename)
+        elif(item == 'SUM'):
+            total_lines = int(cloc_data[item]['code'])
+                
+    # Make GraphQL Call for PR Fraction
+    pr_total_lines = pr_gql.pr_fraction_gql(owner_repo, list_of_files, token)
+
+    # Get total lines of code in Repository
+    fraction = round(float(pr_total_lines)/float(total_lines), 2)
+    print(total_lines)
+    print(fraction, end="")
+    print(" percent of lines of code added through PR")
+    
+    # Round the score to the nearest tenth
+    pr_score = fraction#round(fraction * 1, 1)
+        
+    # Team 9 Code to Write on JSON File
+    try:
+        with open(jsonfile, "r") as f:
+            data = json.load(f)
+    except:
+        data = {}
+    if orig_url in data:
+        data[orig_url]["PR_Fraction"] = pr_score
+    else:
+        data[orig_url] = {"PR_Fraction": pr_score}
+
+    # Write the updated JSON data back to the file
+    with open(jsonfile, "w") as f:
+        json.dump(data, f, indent=4)
+    
+    # After using Git Repo, delete the Folder
+    if(os.path.isdir(path)):
+        shutil.rmtree(path)
+    
+    return
+
+if __name__ == "__main__":
+    # sys args are the url and the json file
+    url = sys.argv[1]
+    orig_url = url
+    jsonfile = sys.argv[2]
+    
+    # Regex the Package name and get the Github Owner and Repo
+    if(url.__contains__("npmjs")):
+        package_name = re.search(r"/package/([\w-]+)", url).group(1)
+        owner_repo = str(vu.npm_to_git(package_name))[1:]
+        url = f"https://github.com/{owner_repo}"
+    else:
+        owner_repo = url.replace("https://github.com/", "")
+
+    # Checks if valid url, and then calls score function
+    if (vu.valid_url(url)):
+        score(url, orig_url, owner_repo, jsonfile)

--- a/server/src/inputs/commands/pr_gql.py
+++ b/server/src/inputs/commands/pr_gql.py
@@ -1,0 +1,76 @@
+import requests
+
+def pr_fraction_gql(owner_repo, list_of_files, token):
+  
+  # Get Owner and Repo Separated
+  owner_repo_list = owner_repo.split("/")
+  owner, repo = owner_repo_list[0], owner_repo_list[1]
+  
+  # Pagination and File variables
+  page_size = 100
+  end_cursor = None
+  has_next_page = True
+  additions = 0
+  deletions = 0
+
+  # Loop through pages of results until no more pages
+  while has_next_page:
+    # GraphQL query
+      query = """
+      query($owner: String!, $name: String!, $pageSize: Int!, $endCursor: String) {
+        repository(owner: $owner, name: $name) {
+          pullRequests(states: MERGED, first: $pageSize, after: $endCursor, orderBy: {field: CREATED_AT, direction: ASC}) {
+            nodes {
+              number
+              files(first: 100) {
+                nodes {
+                  path
+                  additions
+                  deletions
+                }
+              }
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+          }
+        }
+      }
+      """
+      
+      # Query Variables
+      variables = {
+          "owner": owner,
+          "name": repo,
+          "pageSize": page_size,
+          "endCursor": end_cursor
+      }
+      
+      headers = {"Authorization": "Bearer {}".format(token)}
+      
+      # Execute query and retrieve results
+      result = requests.post("https://api.github.com/graphql", json={ "query": query, "variables": variables }, headers=headers)
+
+      # If data is not in this format, skip the Pull Request
+      try:
+        data = result.json()["data"]["repository"]["pullRequests"]
+      except:
+        data = None
+      
+      if data is not None:
+        # Loop through nodes and append file data to results list
+        for node in data["nodes"]:
+            for file in node["files"]["nodes"]:
+                if(file["path"] in list_of_files): # Only add files that were counted by Cloc
+                  additions += int(file["additions"])
+                  deletions += int(file["deletions"])
+      
+      # Check if there are more pages
+      has_next_page = data["pageInfo"]["hasNextPage"]
+      if has_next_page:
+          end_cursor = data["pageInfo"]["endCursor"]
+  
+  total_lines = additions - deletions
+  
+  return total_lines

--- a/server/src/inputs/commands/pr_gql.py
+++ b/server/src/inputs/commands/pr_gql.py
@@ -15,7 +15,7 @@ def pr_fraction_gql(owner_repo, list_of_files, token):
 
   # Loop through pages of results until no more pages
   while has_next_page:
-    # GraphQL query
+    # GraphQL query that filters merged and reviewed (at least once) Pulled Requests
       query = """
       query($owner: String!, $name: String!, $pageSize: Int!, $endCursor: String) {
         repository(owner: $owner, name: $name) {
@@ -28,6 +28,9 @@ def pr_fraction_gql(owner_repo, list_of_files, token):
                   additions
                   deletions
                 }
+              }
+              reviews(first: 1) {
+                totalCount
               }
             }
             pageInfo {

--- a/server/src/inputs/commands/valid_url.py
+++ b/server/src/inputs/commands/valid_url.py
@@ -8,6 +8,7 @@
 # import 
 import sys
 import re
+import requests
 
 def valid_url(url):
     # check if the url is valid with regex
@@ -39,7 +40,20 @@ def get_api_url(url):
     
     return None
         
-    
+def npm_to_git(package_name):
+    url = f"https://registry.npmjs.org/{package_name}"
+    getGit = requests.get(url)
+    if getGit.status_code == 200:
+        if "repository" in getGit.json() or "url" in getGit.json():
+            gitURL = getGit.json()["repository"]["url"]
+            if "github" in gitURL:
+                result = re.search(r"/([\w-]+)/([\w-]+)", gitURL.lower())
+                git_owner = ""
+                if result is not None:
+                    git_owner = result[0]
+                else: git_owner = "Github Regex Fail!"
+                return git_owner
+    return "npm_to_git API Error"      
 
 if __name__ == "__main__":
     # get the input and output file

--- a/server/test/trial.txt
+++ b/server/test/trial.txt
@@ -1,0 +1,4 @@
+https://github.com/cloudinary/cloudinary_npm
+https://www.npmjs.com/package/express
+https://github.com/nullivex/nodist
+https://github.com/jonschlinkert/even


### PR DESCRIPTION
**Testing**:
- Need to decide if testing will be done in the same way Team 9 has, or if we continue Pytest

**How Pull Request Fraction works** 
-  It scans the current files in the Repository with the help of cloc
- It will track all of the changes of the files that have maintained their current path, and track very little changes from files that have changed directory or filenames 
- (e.g src/server.py) if server.py was named server1.py previously for example, and then changed to just server.py, with no code additions or deletions, the line counts for the file will be 0 because server1.py doesn't exist anymore by how cloc scans files, and scan.py could've been committed instead of being merged by a pull request
- This does hinder the total fraction of very big repositories (react, react-native), that received a fraction of 2% when tested
- Other repositories like express, and others we've used have passed with flying colors with fractions above 60%
- Our Project 1 Repository for example received a 51%, due to the fact of last minute direct commits to the Repo, and the fact that we changed our directories and paths a lot

**Solution**
- Open to any solutions to solve this problem if anything